### PR TITLE
deleting the old gmx socket file before starting new

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+
+	"log"
 )
 
 func localSocket() (net.Listener, error) {
@@ -14,8 +16,14 @@ func localSocket() (net.Listener, error) {
 }
 
 func localSocketAddr() *net.UnixAddr {
+	gmxFilePath := filepath.Join(os.TempDir(), fmt.Sprintf(".gmx.%d.%d", os.Getpid(), GMX_VERSION))
+	if _, err := os.Stat(gmxFilePath); err == nil {
+		log.Printf("File %s already exists, deleting it before creating another\n", gmxFilePath)
+		err = os.Remove(gmxFilePath)
+		log.Printf("Unable to delete file %s. Error: %q\n", gmxFilePath, err)
+	}
 	return &net.UnixAddr{
-		filepath.Join(os.TempDir(), fmt.Sprintf(".gmx.%d.%d", os.Getpid(), GMX_VERSION)),
+		gmxFilePath,
 		"unix",
 	}
 }


### PR DESCRIPTION
old gmx files aren't getting cleaned up -- so can't be read afterwards. Ensuring that there isn't a conflicting one before creating new.
